### PR TITLE
Terraform blob storage backend

### DIFF
--- a/azure/main.tf
+++ b/azure/main.tf
@@ -13,6 +13,13 @@ terraform {
     }
   }
 
+  backend "azurerm" {
+    resource_group_name  = "dump-cloud-snowflakes"
+    storage_account_name = "tfstate2022"
+    container_name       = "tfstate"
+    key                  = "terraform.tfstate"
+  }
+
   required_version = ">= 1.2.0"
 }
 


### PR DESCRIPTION
This PR adds Microsoft Azure Blob Storage backend for terraform state. This is useful for multiple people deploying same infrastructure because terraform state is stored locally by default.